### PR TITLE
fix: remove files with sudo

### DIFF
--- a/extract/action.yml
+++ b/extract/action.yml
@@ -43,4 +43,5 @@ runs:
     - name: Move Cache into Its Place
       shell: bash
       run: |
-        rm -rf ${{ inputs.cache-source }} && mv ${{ inputs.scratch-dir }}/dance-cache ${{ inputs.cache-source }}
+        sudo rm -rf ${{ inputs.cache-source }}
+        mv ${{ inputs.scratch-dir }}/dance-cache ${{ inputs.cache-source }}


### PR DESCRIPTION
We are running into issue when running `go mod download` inside a container as root as the action can't remove the files afterwards.

```
rm: cannot remove 'go-mod-cache/github.com/!data!dog/go-tuf@v0.3.0--fix-localmeta-fork/client/python_interop/testdata/python-tuf-v0.11.1/generate.py': Permission denied
rm: cannot remove 'go-mod-cache/github.com/!data!dog/go-tuf@v0.3.0--fix-localmeta-fork/client/python_interop/testdata/LICENSE.txt': Permission denied
rm: cannot remove 'go-mod-cache/github.com/!data!dog/go-tuf@v0.3.0--fix-localmeta-fork/client/python_interop/python_interop_test.go': Permission denied
rm: cannot remove 'go-mod-cache/github.com/!data!dog/go-tuf@v0.3.0--fix-localmeta-fork/client/leveldbstore/leveldbstore.go': Permission denied
rm: cannot remove 'go-mod-cache/github.com/!data!dog/go-tuf@v0.3.0--fix-localmeta-fork/client/leveldbstore/leveldbstore_test.go': Permission denied
```

Adding sudo should fix this.