### PR TITLE
feat: use tiny image and avoid context sending

### DIFF
--- a/extract/action.yml
+++ b/extract/action.yml
@@ -22,7 +22,7 @@ runs:
       run: |
         cat > ${{ inputs.scratch-dir }}/Dancefile.extract <<EOF
         FROM busybox:1
-        COPY ${{ inputs.scratch-dir }}/buildstamp buildstamp
+        COPY buildstamp buildstamp
         RUN --mount=type=cache,target=${{ inputs.cache-target }} \
             mkdir -p /var/dance-cache/ \
             && cp -R ${{ inputs.cache-target }}/* /var/dance-cache/ || true
@@ -31,7 +31,7 @@ runs:
     - name: Extract Data into Docker Image
       shell: bash
       run: |
-        docker buildx build -f ${{ inputs.scratch-dir }}/Dancefile.extract --tag dance:extract --load .
+        docker buildx build -f ${{ inputs.scratch-dir }}/Dancefile.extract --tag dance:extract --load ${{ inputs.scratch-dir }}
     - name: Create Extraction Image
       shell: bash
       run: |

--- a/extract/action.yml
+++ b/extract/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Unpack Docker Image into Scratch
       shell: bash
       run: |
-          docker cp -L cache-container:/var/dance-cache - | tar -x -m -C ${{ inputs.scratch-dir }}
+        docker cp -L cache-container:/var/dance-cache - | tar -x -m -C ${{ inputs.scratch-dir }}
     - name: Move Cache into Its Place
       shell: bash
       run: |

--- a/extract/action.yml
+++ b/extract/action.yml
@@ -25,7 +25,7 @@ runs:
         COPY buildstamp buildstamp
         RUN --mount=type=cache,target=${{ inputs.cache-target }} \
             mkdir -p /var/dance-cache/ \
-            && cp -R ${{ inputs.cache-target }}/* /var/dance-cache/ || true
+            && cp -R ${{ inputs.cache-target }}/. /var/dance-cache/ || true
         EOF
         cat ${{ inputs.scratch-dir }}/Dancefile.extract
     - name: Extract Data into Docker Image

--- a/extract/action.yml
+++ b/extract/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |
         cat > ${{ inputs.scratch-dir }}/Dancefile.extract <<EOF
-        FROM alpine:3.17
+        FROM busybox:1
         COPY ${{ inputs.scratch-dir }}/buildstamp buildstamp
         RUN --mount=type=cache,target=${{ inputs.cache-target }} \
             mkdir -p /var/dance-cache/ \

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -26,7 +26,7 @@ runs:
       run: |
         cat > ${{ inputs.scratch-dir }}/Dancefile.inject <<EOF
         FROM busybox:1
-        COPY ${{ inputs.scratch-dir }}/buildstamp buildstamp
+        COPY buildstamp buildstamp
         RUN --mount=type=cache,target=${{ inputs.cache-target }} \
             --mount=type=bind,source=.,target=/var/dance-cache \
             cp -R /var/dance-cache/* ${{ inputs.cache-target }} || true

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Prepare Timestamp for Layer Cache Busting
       shell: bash
       run: |
-        date --iso=ns | tee ${{ inputs.scratch-dir }}/buildstamp
+        date --iso=ns | tee ${{ inputs.cache-source }}/buildstamp
     - name: Prepare Dancefile to Access Caches
       shell: bash
       run: |

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -36,3 +36,7 @@ runs:
       shell: bash
       run: |
         docker buildx build -f ${{ inputs.scratch-dir }}/Dancefile.inject --tag dance:inject ${{ inputs.cache-source }}
+    - name: Clean Directories
+      shell: bash
+      run: |
+        sudo rm -rf ${{ inputs.cache-source }}

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -29,7 +29,7 @@ runs:
         COPY buildstamp buildstamp
         RUN --mount=type=cache,target=${{ inputs.cache-target }} \
             --mount=type=bind,source=.,target=/var/dance-cache \
-            cp -R /var/dance-cache/* ${{ inputs.cache-target }} || true
+            cp -R /var/dance-cache/. ${{ inputs.cache-target }} || true
         EOF
         cat ${{ inputs.scratch-dir }}/Dancefile.inject
     - name: Inject Data into Docker Cache

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -28,11 +28,11 @@ runs:
         FROM busybox:1
         COPY ${{ inputs.scratch-dir }}/buildstamp buildstamp
         RUN --mount=type=cache,target=${{ inputs.cache-target }} \
-            --mount=type=bind,source=${{ inputs.cache-source }},target=/var/dance-cache \
+            --mount=type=bind,source=.,target=/var/dance-cache \
             cp -R /var/dance-cache/* ${{ inputs.cache-target }} || true
         EOF
         cat ${{ inputs.scratch-dir }}/Dancefile.inject
     - name: Inject Data into Docker Cache
       shell: bash
       run: |
-        docker buildx build -f ${{ inputs.scratch-dir }}/Dancefile.inject --tag dance:inject .
+        docker buildx build -f ${{ inputs.scratch-dir }}/Dancefile.inject --tag dance:inject ${{ inputs.cache-source }}

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: |
         cat > ${{ inputs.scratch-dir }}/Dancefile.inject <<EOF
-        FROM alpine:3.17
+        FROM busybox:1
         COPY ${{ inputs.scratch-dir }}/buildstamp buildstamp
         RUN --mount=type=cache,target=${{ inputs.cache-target }} \
             --mount=type=bind,source=${{ inputs.cache-source }},target=/var/dance-cache \


### PR DESCRIPTION
A few additional changes:

* alpine is fairly large if we just want to  copy, [busybox](https://hub.docker.com/_/busybox) is good enough.
* the working directory might be large and is always transferred as context, so specific only the cache source as context to avoid this
* cleanup the cache-source by default to avoid impacting all docker build steps below as those would also need to transfer the context