### PR TITLE
Unify `inject` and `extract` into a single action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+---
+name: Test
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: test
+      - name: Cache var-cache-apt
+        uses: actions/cache@v3
+        with:
+          path: var-cache-apt
+          key: var-cache-apt-${{ hashFiles('.github/workflows/test/Dockerfile') }}
+      - name: Cache var-lib-apt
+        uses: actions/cache@v3
+        with:
+          path: var-lib-apt
+          key: var-lib-apt-${{ hashFiles('.github/workflows/test/Dockerfile') }}
+      - name: inject var-cache-apt into docker
+        uses: ./
+        with:
+          cache-source: var-cache-apt
+          cache-target: /var/cache/apt
+      - name: inject var-lib-apt into docker
+        uses: ./
+        with:
+          cache-source: var-lib-apt
+          cache-target: /var/lib/apt
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .github/workflows/test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test/Dockerfile
+++ b/.github/workflows/test/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt update && \
+  apt-get --no-install-recommends install -y gcc

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ jobs:
           path: go-build-cache
           key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
 
-      - name: inject go-build-cache into docker
-        uses: overmindtech/buildkit-cache-dance/inject@main
+      - name: inject/extract go-build-cache into docker
+        uses: overmindtech/buildkit-cache-dance@main
         with:
           cache-source: go-build-cache
 
@@ -54,12 +54,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-
-      - name: extract go-build-cache from docker
-        uses: overmindtech/buildkit-cache-dance/extract@main
-        with:
-          cache-source: go-build-cache
-
 ```
 
 Thanks to [Alexander Pravdin](https://github.com/speller) for the basic idea in [this comment](https://github.com/moby/buildkit/issues/1512).

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,58 @@
+name: Inject/Extract Cache
+description: "Injects the cached data into the docker build(x|kit) process"
+inputs:
+  cache-source:
+    default: cache
+    description: "Where the cache is stored in the calling workspace. Default: `cache`"
+  cache-target:
+    default: /root/.cache/go-build
+    description: "Where the cache is stored in the docker container. Default: `/root/.cache/go-build`"
+  scratch-dir:
+    default: scratch
+    description: "Where the action is stores some temporary files for its processing. Default: `scratch`"
+runs:
+  using: composite
+  steps:
+    - uses: pyTooling/Actions/with-post-step@adef08d3bdef092282614f3b683897cefae82ee3  # v0.4.6
+      with:
+        main: |-
+          set -eux
+          # Clean Directories
+          rm -Rf ${{ inputs.scratch-dir }} && mkdir -p ${{ inputs.scratch-dir }} ${{ inputs.cache-source }}
+          # Prepare Timestamp for Layer Cache Busting
+          date --iso=ns | tee ${{ inputs.cache-source }}/buildstamp
+          # Prepare Dancefile to Access Caches
+          cat > ${{ inputs.scratch-dir }}/Dancefile.inject <<EOF
+          FROM busybox:1
+          COPY buildstamp buildstamp
+          RUN --mount=type=cache,target=${{ inputs.cache-target }} \
+              --mount=type=bind,source=.,target=/var/dance-cache \
+              cp -p -R /var/dance-cache/. ${{ inputs.cache-target }} || true
+          EOF
+          cat ${{ inputs.scratch-dir }}/Dancefile.inject
+          # Inject Data into Docker Cache
+          docker buildx build -f ${{ inputs.scratch-dir }}/Dancefile.inject --tag dance:inject ${{ inputs.cache-source }}
+          # Clean Directories
+          sudo rm -rf ${{ inputs.cache-source }}
+        post: |-
+          set -eux
+          # Prepare Timestamp for Layer Cache Busting
+          date --iso=ns | tee ${{ inputs.scratch-dir }}/buildstamp
+          # Prepare Dancefile to Access Caches
+          cat > ${{ inputs.scratch-dir }}/Dancefile.extract <<EOF
+          FROM busybox:1
+          COPY buildstamp buildstamp
+          RUN --mount=type=cache,target=${{ inputs.cache-target }} \
+              mkdir -p /var/dance-cache/ \
+              && cp -p -R ${{ inputs.cache-target }}/. /var/dance-cache/ || true
+          EOF
+          cat ${{ inputs.scratch-dir }}/Dancefile.extract
+          # Extract Data into Docker Image
+          docker buildx build -f ${{ inputs.scratch-dir }}/Dancefile.extract --tag dance:extract --load ${{ inputs.scratch-dir }}
+          # Create Extraction Image
+          docker rm -f cache-container && docker create -ti --name cache-container dance:extract
+          # Unpack Docker Image into Scratch
+          docker cp -L cache-container:/var/dance-cache - | tar -H posix -x -C ${{ inputs.scratch-dir }}
+          # Move Cache into Its Place
+          sudo rm -rf ${{ inputs.cache-source }}
+          mv ${{ inputs.scratch-dir }}/dance-cache ${{ inputs.cache-source }}

--- a/extract/action.yml
+++ b/extract/action.yml
@@ -1,3 +1,4 @@
+# Deprecated. Use ../action.yml instead.
 name: Extract Cache
 description: "Extracts the cached data from the docker build(x|kit) process"
 inputs:

--- a/inject/action.yml
+++ b/inject/action.yml
@@ -1,3 +1,4 @@
+# Deprecated. Use ../action.yml instead.
 name: Inject Cache
 description: "Injects the cached data into the docker build(x|kit) process"
 inputs:


### PR DESCRIPTION
Fix #7

The old `inject` and `extract` actions are now deprecated but still kept in the repo to avoid breaking somebody's workflow.